### PR TITLE
add type checking string and new error

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ import isValidCoordinates from 'is-valid-coordinates';
 const PLATFORM = Platform.OS;
 
 export const OpenMapDirections = (frmCoord = null, toCoord, transportType) => new Promise((resolve, reject) => {
-	const _toCoord;
+	let _toCoord;
 	const _frmCoord = _checkParameters(frmCoord) !== null ? `?saddr=${_checkParameters(frmCoord)}` : '';
 	if (_checkParameters(toCoord) !== null) {
 		_toCoord = `&daddr=${_checkParameters(toCoord)}`

--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@ import isValidCoordinates from 'is-valid-coordinates';
 const PLATFORM = Platform.OS;
 
 export const OpenMapDirections = (frmCoord = null, toCoord, transportType) => new Promise((resolve, reject) => {
+	const _toCoord;
 	const _frmCoord = _checkParameters(frmCoord) !== null ? `?saddr=${_checkParameters(frmCoord)}` : '';
 	if (_checkParameters(toCoord) !== null) {
-		const _toCoord = `&daddr=${_checkParameters(toCoord)}`
+		_toCoord = `&daddr=${_checkParameters(toCoord)}`
 	} else {
 		throw new Error('You need to pass a valid endpoint(number)')
 	};

--- a/index.js
+++ b/index.js
@@ -5,7 +5,11 @@ const PLATFORM = Platform.OS;
 
 export const OpenMapDirections = (frmCoord = null, toCoord, transportType) => new Promise((resolve, reject) => {
 	const _frmCoord = _checkParameters(frmCoord) !== null ? `?saddr=${_checkParameters(frmCoord)}` : '';
-	const _toCoord = _checkParameters(toCoord) !== null ? `&daddr=${_checkParameters(toCoord)}` : '';
+	if (_checkParameters(toCoord) !== null) {
+		const _toCoord = `&daddr=${_checkParameters(toCoord)}`
+	} else {
+		throw new Error('You need to pass a valid endpoint(number)')
+	};
 	const _transportType = _checkTransportParameter(transportType) !== null ? `&dirflg=${_checkTransportParameter(transportType)}` : '';
 	const url = `${PLATFORM === 'ios' ? `http://maps.apple.com/` : 'http://maps.google.com/'}${_frmCoord}${_toCoord}${_transportType}`;
 	_openApp(url).then(result => { resolve(result) });
@@ -24,7 +28,7 @@ const _openApp = (url) => new Promise((resolve, reject) => {
 });
 
 const _checkParameters = (param) => {
-	if (param === null || param === undefined) { return null; }
+	if (param === null || param === undefined || typeof param === 'string') { return null; }
 
 	if (isValidCoordinates.longitude(param.longitude) && isValidCoordinates.latitude(param.latitude)) {
 		return `${param.latitude},${param.longitude}`


### PR DESCRIPTION
I made a small change to check if the coordinates were string. In the future user will get an error if they pass in a string number instead of number

Another change is to throw error instead of returning empty string since empty string does not point to a direction. This will help user to find bug easier  