### PR TITLE
fix lat and long type checking

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ const _openApp = (url) => new Promise((resolve, reject) => {
 });
 
 const _checkParameters = (param) => {
-	if (param === null || param === undefined || typeof param === 'string') { return null; }
+	if (param === null || param === undefined || typeof param.latitude === 'string' || typeof param.longitude === 'string') { return null; }
 
 	if (isValidCoordinates.longitude(param.longitude) && isValidCoordinates.latitude(param.latitude)) {
 		return `${param.latitude},${param.longitude}`


### PR DESCRIPTION
This changes is to fix my previous pull request that I made. Instead of checking the value of the object (in this case, latitude and longitude), I made a mistake of type checking on the object itself. So this changes is to check the latitude and longitude values.

The motive behind it is to prevent user from accidentally pass in string numbers instead of numbers.