### PR TITLE
fixed url params starting with `&` and therefore passing no parameter…

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ export const OpenMapDirections = (frmCoord = null, toCoord, transportType) => ne
 	let _toCoord;
 	const _frmCoord = _checkParameters(frmCoord) !== null ? `?saddr=${_checkParameters(frmCoord)}` : '';
 	if (_checkParameters(toCoord) !== null) {
-		_toCoord = `&daddr=${_checkParameters(toCoord)}`
+		_toCoord = (_frmCoord.length == 0 ? '?' : '&') + `daddr=${_checkParameters(toCoord)}`
 	} else {
 		throw new Error('You need to pass a valid endpoint(number)')
 	};


### PR DESCRIPTION
…s to maps.